### PR TITLE
Removing the application field

### DIFF
--- a/src/kixi/log/timbre/appenders/logstash.clj
+++ b/src/kixi/log/timbre/appenders/logstash.clj
@@ -30,13 +30,12 @@
       (not-empty-str (force (:msg_ data))))))
 
 (defn log->json
-  [app-name data]
+  [data]
   (let [opts (get-in data [:config :options])
         exp (some-> (force (:?err data)) exception->map)
         msg (or (extract-msg data) (:message exp))]
     {:level (:level data)
      :namespace (:?ns-str data)
-     :application app-name
      :file (:?file data)
      :line (:?line data)
      :exception exp
@@ -51,18 +50,18 @@
     (.get lock-field writer)))
 
 (defn json->out
-  [app-name]
+  []
   (let [lock (get-lock *out*)]
     (fn [data]
       (locking lock
         (json/generate-stream
-         (log->json app-name data)
+         (log->json data)
          *out*)
         (prn)))))
 
 (defn json-appender
-  [app-name]
+  []
   {:enabled?   true
    :async?     false
    :output-fn identity
-   :fn (json->out app-name)})
+   :fn (json->out)})

--- a/test/kixi/log_test.clj
+++ b/test/kixi/log_test.clj
@@ -12,7 +12,7 @@
 (deftest timbre-appender-logstash-test
   (timbre/set-config! {:level :info
                        :timestamp-opts default-timestamp-opts
-                       :appenders {:direct-json (timbre-appender-logstash "my-app")}})
+                       :appenders {:direct-json (timbre-appender-logstash)}})
   (testing "Logstash keys are present"
     (let [result-str  (with-out-str (timbre/info "foobar"))
           result-json (as-json result-str)]
@@ -20,13 +20,11 @@
       (is (contains? result-json :msg))
       (is (contains? result-json :level))
       (is (contains? result-json :namespace))
-      (is (contains? result-json :application))
       (is (contains? result-json :file))
       (is (contains? result-json :line))
       (is (contains? result-json :exception))
       (is (contains? result-json :hostname))
-      (is (contains? result-json (keyword "@timestamp")))
-      (is (= "my-app" (:application result-json) ))))
+      (is (contains? result-json (keyword "@timestamp")))))
 
   (testing "Normal string msg, single-arity"
     (let [result-str  (with-out-str (timbre/info "foobar"))


### PR DESCRIPTION
This field will now be auto-magically created by the docker logging driver